### PR TITLE
Add `publishConfig` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "style/index.js"
   ],
   "styleModule": "style/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "outputDir": "jupyterlite_echo_kernel/labextension",


### PR DESCRIPTION
Fixes failed automated publish to npm