### PR TITLE
Automated Changelog Entry for 0.1.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.2
+
+([Full Changelog](https://github.com/jupyterlite/echo-kernel/compare/v0.1.1...4310974489efbc684247860a6f573e88449ab2e4))
+
+### Bugs fixed
+
+- Add `publishConfig` to `package.json` [#3](https://github.com/jupyterlite/echo-kernel/pull/3) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/echo-kernel/graphs/contributors?from=2021-10-01&to=2021-11-15&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fecho-kernel+involves%3Ajtpio+updated%3A2021-10-01..2021-11-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.1
 
 ([Full Changelog](https://github.com/jupyterlite/echo-kernel/compare/first-commit...dd8dcc9f59b4ec20c60560db0b94cea932f29bfe))
@@ -15,5 +31,3 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/echo-kernel/graphs/contributors?from=2021-10-01&to=2021-10-01&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fecho-kernel+involves%3Ajtpio+updated%3A2021-10-01..2021-10-01&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.2 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/echo-kernel  |
| Branch  | main  |
| Version Spec | 0.1.2 |
| Since | v0.1.1 |