### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/jupyterlite/echo-kernel/compare/v0.1.2...1a30deec6901f5a6d35aa0f0ac571f1acb076c90))
+
+### Bugs fixed
+
+- Fix duplication in the spec [#6](https://github.com/jupyterlite/echo-kernel/pull/6) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/echo-kernel/graphs/contributors?from=2021-11-15&to=2022-06-08&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fecho-kernel+involves%3Ajtpio+updated%3A2021-11-15..2022-06-08&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.2
 
 ([Full Changelog](https://github.com/jupyterlite/echo-kernel/compare/v0.1.1...4310974489efbc684247860a6f573e88449ab2e4))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/echo-kernel/graphs/contributors?from=2021-10-01&to=2021-11-15&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fecho-kernel+involves%3Ajtpio+updated%3A2021-10-01..2021-11-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/echo-kernel  |
| Branch  | main  |
| Version Spec | 0.2.0 |
| Since Last Stable | true |