### PR TITLE
Use Node.js version to 24 to publish packages

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,6 +20,8 @@ jobs:
       id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          node_version: '24'
 
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
To use trusted publishers.